### PR TITLE
Add buildtool and exec depends on python3 for packaging.

### DIFF
--- a/cli_tools_py/package.xml
+++ b/cli_tools_py/package.xml
@@ -8,6 +8,9 @@
   <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
   <license>Apache License 2.0</license>
 
+  <buildtool_depend>python3</buildtool_depend>
+
+  <exec_depend>python3</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Needed to build properly on the ROS 2 testfarm.